### PR TITLE
Add TLS.IgnoreInsecure option to skip certificate verification

### DIFF
--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -16,7 +16,7 @@ jobs:
     steps:
       - name: Setup go
         uses: actions/setup-go@v5
-        with: { go-version: '1.24.x' }
+        with: { go-version: '1.25.x' }
 
       - name: Check out code
         uses: actions/checkout@v4
@@ -39,12 +39,17 @@ jobs:
 
       - name: Nancy (deps vulnerabilities)
         uses: sonatype-nexus-community/nancy-github-action@main
+        with:
+          githubToken: ${{ github.token }}
+        env:
+          OSSI_USERNAME: ${{ secrets.OSSINDEX_USERNAME }}
+          OSSI_TOKEN: ${{ secrets.OSSINDEX_TOKEN }}
 
   build:
     name: Build
     runs-on: ubuntu-latest
     needs: lint
-    strategy: { matrix: { go: [ '1.24.x' ] } }
+    strategy: { matrix: { go: [ '1.24.x', '1.25.x' ] } }
     steps:
       - name: Setup go
         uses: actions/setup-go@v5

--- a/README.md
+++ b/README.md
@@ -28,7 +28,7 @@ the configuration into the current instance.
 
 To use this provider plugin:
 
-1. Enable experimental plugins in your Traefik configuration:
+1. Enable experimental plugins in your Traefik configuration ("v0.1.0" - check latest version):
     ```yaml
     experimental:
       plugins:
@@ -49,6 +49,9 @@ To use this provider plugin:
             - host: localhost
               apiPort: 8080
               webPort: 5180
+              # if you use HTTPS
+              tls:
+                ignoreInsecure: true
     ```
 
 ## Configuration
@@ -68,11 +71,15 @@ Each endpoint in `endpoints` should include:
 - host: 127.0.0.1
   apiPort: 8080
   webPort: 80
+  # if you use HTTPS
+  tls:
+    ignoreInsecure: true
 ```
 
 * `host`: IP or hostname of the remote Traefik
 * `apiPort`: Port used to fetch `/api/rawdata`
 * `webPort`: Port used for service routing
+* `tls.ignoreInsecure`: should be true, if you use HTTPS between public and private traefik, but need self-signed certs
 
 ## Use Case
 

--- a/provider_test.go
+++ b/provider_test.go
@@ -88,6 +88,7 @@ func TestProvider(t *testing.T) {
 								Servers: []dynamic.Server{{URL: (&url.URL{
 									Scheme: "http",
 									Host:   addr.String(),
+									Path:   "/",
 								}).String()}},
 							},
 						},


### PR DESCRIPTION
This commit introduces a new TLS configuration option that allows ignoring insecure TLS certificates when connecting to endpoints.

Changes:
- Add TLS struct with IgnoreInsecure field to Endpoint configuration
- Implement HTTP client transport with InsecureSkipVerify when enabled
- Refactor URI construction into dedicated buildURI method
- Add comprehensive test case for TLS ignore functionality
- Update client code to use new URI builder consistently

The new option is useful for development environments and testing with self-signed certificates. When TLS.IgnoreInsecure is set to true, the HTTP client will skip certificate verification while maintaining HTTPS scheme in requests.

Example configuration:
```yaml
endpoints:
  - host: localhost
    apiPort: 5180
    webPort: 5080
    tls:
      ignoreInsecure: true
```

This maintains backward compatibility - existing configurations without TLS section continue to work as before with plain HTTP connections.

Closes #2 

cc @RichyHBM 