### PR TITLE
Support multiple endpoints and improve error handling

### DIFF
--- a/internal/client.go
+++ b/internal/client.go
@@ -7,7 +7,9 @@ import (
 	"errors"
 	"fmt"
 	"io"
+	"net"
 	"net/http"
+	"strconv"
 	"strings"
 
 	"github.com/traefik/genconf/dynamic"
@@ -24,12 +26,16 @@ const defaultRawPath = "/api/rawdata"
 
 var ErrEmptyResponse = errors.New("received empty response")
 
+func PrepareName(name, endpoint string) string {
+	return fmt.Sprintf("%s-%s", name, strings.NewReplacer(".", "_", ":", "__").Replace(endpoint))
+}
+
 func (c *Client) Endpoint() string {
 	if c == nil {
 		return "empty"
 	}
 
-	return c.endpoint.Host
+	return net.JoinHostPort(c.endpoint.Host, strconv.Itoa(c.endpoint.API))
 }
 
 func (c *Client) httpCall(ctx context.Context) (*dynamic.Configuration, error) {
@@ -57,14 +63,15 @@ func (c *Client) httpCall(ctx context.Context) (*dynamic.Configuration, error) {
 }
 
 func (c *Client) prepareResponse(res *dynamic.Configuration) *dynamic.Configuration {
+	endpoint := c.Endpoint()
+
 	var output dynamic.Configuration
 	for key, item := range res.HTTP.Routers {
 		if strings.HasSuffix(key, "@internal") {
 			continue
 		}
 
-		name := strings.Split(key, "@")[0]
-		name = fmt.Sprintf("%s-%s", name, c.endpoint.Host)
+		name := PrepareName(strings.Split(key, "@")[0], endpoint)
 
 		service, ok := res.HTTP.Services[key]
 		if !ok {
@@ -116,11 +123,10 @@ func (c *Client) prepareResponse(res *dynamic.Configuration) *dynamic.Configurat
 	return &output
 }
 
-func (c *Client) FetchRaw(ctx context.Context, out chan<- *dynamic.Configuration) error {
-	if res, err := c.httpCall(ctx); err != nil {
-		out <- nil
-
-		return err
+func (c *Client) FetchRaw(ctx context.Context, out chan<- *dynamic.Configuration) (err error) {
+	var res *dynamic.Configuration
+	if res, err = c.httpCall(ctx); err != nil {
+		err = fmt.Errorf("(client:%q): %w", c.Endpoint(), err)
 	} else if len(res.HTTP.Routers) > 0 && len(res.HTTP.Services) > 0 {
 		out <- c.prepareResponse(res)
 
@@ -128,6 +134,9 @@ func (c *Client) FetchRaw(ctx context.Context, out chan<- *dynamic.Configuration
 	}
 
 	out <- nil
+	if err == nil {
+		err = fmt.Errorf("(client:%q): %w", c.Endpoint(), ErrEmptyResponse)
+	}
 
-	return fmt.Errorf("%w (1client:%q)", ErrEmptyResponse, c.endpoint.Host)
+	return err
 }

--- a/internal/client_test.go
+++ b/internal/client_test.go
@@ -16,6 +16,8 @@ import (
 	"github.com/traefik/genconf/dynamic"
 )
 
+const whoamiService = "whoami"
+
 func catchError(args ...any) error {
 	if ln := len(args); ln < 0 {
 		return nil
@@ -88,7 +90,7 @@ func TestClient(t *testing.T) {
 	cli, err := cfg.PrepareClients(ctx)
 	require.NoError(t, err)
 
-	require.Equal(t, cli[0].Endpoint(), addr.IP.String())
+	require.Equal(t, cli[0].Endpoint(), addr.String())
 
 	out := make(chan *dynamic.Configuration, 1)
 	if err = cli[0].FetchRaw(t.Context(), out); err != nil {
@@ -104,19 +106,19 @@ func TestClient(t *testing.T) {
 		require.Equal(t, &dynamic.Configuration{
 			HTTP: &dynamic.HTTPConfiguration{
 				Routers: map[string]*dynamic.Router{
-					"whoami-" + addr.IP.String(): {
+					PrepareName(whoamiService, addr.String()): {
 						Middlewares: []string{"http2https"},
-						Service:     "whoami-" + addr.IP.String(),
+						Service:     PrepareName(whoamiService, addr.String()),
 						Rule:        "Host(`whoami.example.com`)",
 					},
-					"whoami-" + addr.IP.String() + "-secure": {
-						Service: "whoami-" + addr.IP.String(),
+					PrepareName(whoamiService, addr.String()) + "-secure": {
+						Service: PrepareName(whoamiService, addr.String()),
 						Rule:    "Host(`whoami.example.com`)",
 						TLS:     &dynamic.RouterTLSConfig{CertResolver: resolver},
 					},
 				},
 				Services: map[string]*dynamic.Service{
-					"whoami-" + addr.IP.String(): {
+					PrepareName(whoamiService, addr.String()): {
 						LoadBalancer: &dynamic.ServersLoadBalancer{
 							Servers: []dynamic.Server{{URL: (&url.URL{
 								Scheme: "http",
@@ -170,7 +172,7 @@ func TestClient_tls(t *testing.T) {
 	cli, err := cfg.PrepareClients(ctx)
 	require.NoError(t, err)
 
-	require.Equal(t, cli[0].Endpoint(), addr.IP.String())
+	require.Equal(t, cli[0].Endpoint(), addr.String())
 
 	out := make(chan *dynamic.Configuration, 1)
 	if err = cli[0].FetchRaw(t.Context(), out); err != nil {
@@ -186,19 +188,19 @@ func TestClient_tls(t *testing.T) {
 		require.Equal(t, &dynamic.Configuration{
 			HTTP: &dynamic.HTTPConfiguration{
 				Routers: map[string]*dynamic.Router{
-					"whoami-" + addr.IP.String(): {
+					PrepareName(whoamiService, addr.String()): {
 						Middlewares: []string{"http2https"},
-						Service:     "whoami-" + addr.IP.String(),
+						Service:     PrepareName(whoamiService, addr.String()),
 						Rule:        "Host(`whoami.example.com`)",
 					},
-					"whoami-" + addr.IP.String() + "-secure": {
-						Service: "whoami-" + addr.IP.String(),
+					PrepareName(whoamiService, addr.String()) + "-secure": {
+						Service: PrepareName(whoamiService, addr.String()),
 						Rule:    "Host(`whoami.example.com`)",
 						TLS:     &dynamic.RouterTLSConfig{CertResolver: resolver},
 					},
 				},
 				Services: map[string]*dynamic.Service{
-					"whoami-" + addr.IP.String(): {
+					PrepareName(whoamiService, addr.String()): {
 						LoadBalancer: &dynamic.ServersLoadBalancer{
 							Servers: []dynamic.Server{{URL: (&url.URL{
 								Scheme: "https",

--- a/provider.go
+++ b/provider.go
@@ -45,7 +45,7 @@ func (p *Provider) Init() error {
 }
 
 func fetchConfig(top context.Context, out chan<- json.Marshaler, clients []*internal.Client) error {
-	merge := make(chan *dynamic.Configuration, 2)
+	merge := make(chan *dynamic.Configuration, len(clients))
 	defer close(merge)
 
 	run := newRunner(top)

--- a/provider_test.go
+++ b/provider_test.go
@@ -1,6 +1,7 @@
 package traefik_provider
 
 import (
+	"bytes"
 	"context"
 	"encoding/json"
 	"net"
@@ -11,9 +12,17 @@ import (
 	"testing"
 	"time"
 
+	"github.com/davecgh/go-spew/spew"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"github.com/traefik/genconf/dynamic"
+
+	"github.com/im-kulikov/traefik-provider/internal"
+)
+
+const (
+	whoamiService = "whoami"
+	testService   = "test"
 )
 
 func catchError(args ...any) error {
@@ -27,16 +36,28 @@ func catchError(args ...any) error {
 }
 
 func TestProvider(t *testing.T) {
-	data, err := os.ReadFile("fixtures/jaeger-api-rawdata.json")
+	dataOne, err := os.ReadFile("fixtures/jaeger-api-rawdata.json")
 	require.NoError(t, err)
 
-	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+	dataTwo := bytes.ReplaceAll(dataOne, []byte(whoamiService), []byte(testService))
+	dataTwo = bytes.ReplaceAll(dataTwo, []byte("192.168.97.2"), []byte("192.168.98.2"))
+
+	srvOne := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
 		w.WriteHeader(http.StatusOK)
 
-		assert.NoError(t, catchError(w.Write(data)))
+		assert.NoError(t, catchError(w.Write(dataOne)))
 	}))
 
-	addr, ok := srv.Listener.Addr().(*net.TCPAddr)
+	srvTwo := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusOK)
+
+		assert.NoError(t, catchError(w.Write(dataTwo)))
+	}))
+
+	addrOne, ok := srvOne.Listener.Addr().(*net.TCPAddr)
+	require.True(t, ok)
+
+	addrTwo, ok := srvTwo.Listener.Addr().(*net.TCPAddr)
 	require.True(t, ok)
 
 	ctx, cancel := context.WithTimeout(t.Context(), time.Millisecond*100)
@@ -49,9 +70,13 @@ func TestProvider(t *testing.T) {
 		PollInterval: "5s",
 		TLSResolver:  &resolver,
 		Endpoints: []Endpoint{{
-			Host: addr.IP.String(),
-			API:  addr.Port,
-			WEB:  addr.Port,
+			Host: addrOne.IP.String(),
+			API:  addrOne.Port,
+			WEB:  addrOne.Port,
+		}, {
+			Host: addrTwo.IP.String(),
+			API:  addrTwo.Port,
+			WEB:  addrTwo.Port,
 		}},
 	}
 
@@ -67,27 +92,49 @@ func TestProvider(t *testing.T) {
 		t.Fatal("no response")
 	case result := <-out:
 		require.ErrorIs(t, p.Stop(), context.Canceled)
+
+		spew.Dump(result)
+
 		require.Equal(t, dynamic.JSONPayload{
 			Configuration: &dynamic.Configuration{
 				HTTP: &dynamic.HTTPConfiguration{
 					Routers: map[string]*dynamic.Router{
-						"whoami-" + addr.IP.String(): {
+						internal.PrepareName(whoamiService, addrOne.String()): {
 							Middlewares: []string{"http2https"},
-							Service:     "whoami-" + addr.IP.String(),
+							Service:     internal.PrepareName(whoamiService, addrOne.String()),
 							Rule:        "Host(`whoami.example.com`)",
 						},
-						"whoami-" + addr.IP.String() + "-secure": {
-							Service: "whoami-" + addr.IP.String(),
+						internal.PrepareName(whoamiService, addrOne.String()) + "-secure": {
+							Service: internal.PrepareName(whoamiService, addrOne.String()),
 							Rule:    "Host(`whoami.example.com`)",
+							TLS:     &dynamic.RouterTLSConfig{CertResolver: resolver},
+						},
+						internal.PrepareName(testService, addrTwo.String()): {
+							Middlewares: []string{"http2https"},
+							Service:     internal.PrepareName(testService, addrTwo.String()),
+							Rule:        "Host(`test.example.com`)",
+						},
+						internal.PrepareName(testService, addrTwo.String()) + "-secure": {
+							Service: internal.PrepareName(testService, addrTwo.String()),
+							Rule:    "Host(`test.example.com`)",
 							TLS:     &dynamic.RouterTLSConfig{CertResolver: resolver},
 						},
 					},
 					Services: map[string]*dynamic.Service{
-						"whoami-" + addr.IP.String(): {
+						internal.PrepareName(whoamiService, addrOne.String()): {
 							LoadBalancer: &dynamic.ServersLoadBalancer{
 								Servers: []dynamic.Server{{URL: (&url.URL{
 									Scheme: "http",
-									Host:   addr.String(),
+									Host:   addrOne.String(),
+									Path:   "/",
+								}).String()}},
+							},
+						},
+						internal.PrepareName(testService, addrTwo.String()): {
+							LoadBalancer: &dynamic.ServersLoadBalancer{
+								Servers: []dynamic.Server{{URL: (&url.URL{
+									Scheme: "http",
+									Host:   addrTwo.String(),
 									Path:   "/",
 								}).String()}},
 							},


### PR DESCRIPTION
- Refactor provider to handle multiple endpoints concurrently by increasing merge channel capacity based on client count
- Enhance client to use full endpoint address (host:port) for service naming instead of just IP, improving uniqueness across multiple instances
- Improve error messages to include endpoint address for better debugging
- Update tests to validate multiple endpoint configurations:
  - Add second test server with modified service data
  - Verify routers and services are created for both endpoints
  - Ensure proper naming with host:port format
- Add internal.PrepareName helper for consistent service naming
- Replace IP-based identifiers with endpoint strings containing port
- Maintain TLS resolver functionality across multiple endpoints

Resolve #1 

cc @RichyHBM 