### PR TITLE
fix: tolerate unreachable endpoints instead of failing closed

### DIFF
--- a/internal/client.go
+++ b/internal/client.go
@@ -118,16 +118,51 @@ func (c *Client) prepareResponse(res *dynamic.Configuration) *dynamic.Configurat
 
 func (c *Client) FetchRaw(ctx context.Context, out chan<- *dynamic.Configuration) error {
 	if res, err := c.httpCall(ctx); err != nil {
-		out <- nil
+		c.emit(ctx, out, nil)
 
 		return err
 	} else if len(res.HTTP.Routers) > 0 && len(res.HTTP.Services) > 0 {
-		out <- c.prepareResponse(res)
+		c.emit(ctx, out, c.prepareResponse(res))
 
 		return nil
 	}
 
-	out <- nil
+	c.emit(ctx, out, nil)
 
 	return fmt.Errorf("%w (1client:%q)", ErrEmptyResponse, c.endpoint.Host)
+}
+
+// emit delivers cfg to out, abandoning the send once ctx is done.
+//
+// out is a small buffered channel drained by a single aggregator. If that
+// aggregator has already stopped collecting -- for example because the poll
+// deadline expired -- an unconditional send would block forever, leaking the
+// goroutine and hanging the WaitGroup the poll loop waits on, which would stop
+// the provider from ever polling again.
+func (c *Client) emit(
+	ctx context.Context,
+	out chan<- *dynamic.Configuration,
+	cfg *dynamic.Configuration,
+) {
+	// Fast path: while the aggregator still has buffer space, deliver
+	// unconditionally. This keeps behaviour identical to a plain send even when
+	// ctx is already cancelled or nil, which callers rely on.
+	select {
+	case out <- cfg:
+		return
+	default:
+	}
+
+	if ctx == nil {
+		out <- cfg
+
+		return
+	}
+
+	// Buffer is full: wait for the aggregator, but abandon the send if the poll
+	// has already been given up on, so this goroutine cannot leak.
+	select {
+	case out <- cfg:
+	case <-ctx.Done():
+	}
 }

--- a/internal/config.go
+++ b/internal/config.go
@@ -5,6 +5,7 @@ import (
 	"crypto/tls"
 	"errors"
 	"fmt"
+	"log"
 	"net/http"
 	"net/url"
 	"time"
@@ -91,6 +92,12 @@ func (c *Config) PrepareClients(top context.Context) ([]*Client, error) {
 			}
 		}
 
+		// The reachability probe is diagnostic only. An endpoint that is down
+		// when the provider is constructed must NOT abort construction: hosts
+		// get rebooted, and a later poll picks them up again. Aborting here
+		// leaves Traefik with no provider at all -- and because Traefik does not
+		// retry a provider that failed to start, every endpoint stays unrouted
+		// until Traefik itself is restarted.
 		var err error
 		for _, port := range []int{endpoint.API, endpoint.WEB} {
 			uri := endpoint.buildURI(port, defaultPath)
@@ -102,11 +109,17 @@ func (c *Config) PrepareClients(top context.Context) ([]*Client, error) {
 
 			var res *http.Response
 			if res, err = cli.Do(req); err != nil {
-				return nil, fmt.Errorf("could not call request(%s): %w", uri, err)
+				log.Printf(
+					"endpoint unreachable at startup, will retry on next poll (%s): %s",
+					uri,
+					err,
+				)
+
+				continue
 			}
 
 			if err = res.Body.Close(); err != nil {
-				return nil, fmt.Errorf("could not close response body: %w", err)
+				log.Printf("could not close response body (%s): %s", uri, err)
 			}
 		}
 

--- a/internal/emit_test.go
+++ b/internal/emit_test.go
@@ -1,0 +1,126 @@
+package internal
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+	"github.com/traefik/genconf/dynamic"
+)
+
+// TestClient_emit covers the delivery guarantees FetchRaw depends on: results
+// must still reach the aggregator on the ordinary path, but a send must never
+// block forever once the poll has been abandoned.
+func TestClient_emit(t *testing.T) {
+	cli := new(Client)
+
+	t.Run("delivers while the buffer has room", func(t *testing.T) {
+		out := make(chan *dynamic.Configuration, 1)
+
+		cli.emit(t.Context(), out, nil)
+		require.Len(t, out, 1)
+	})
+
+	t.Run("delivers with a nil context", func(t *testing.T) {
+		out := make(chan *dynamic.Configuration, 1)
+
+		cli.emit(nil, out, nil) // nolint:staticcheck
+		require.Len(t, out, 1)
+	})
+
+	t.Run("delivers with an already-cancelled context when there is room", func(t *testing.T) {
+		ctx, cancel := context.WithCancel(t.Context())
+		cancel()
+
+		out := make(chan *dynamic.Configuration, 1)
+
+		cli.emit(ctx, out, nil)
+		require.Len(
+			t,
+			out,
+			1,
+			"a cancelled context must not drop a result the aggregator can still accept",
+		)
+	})
+
+	t.Run("waits for room when the context is nil", func(t *testing.T) {
+		// Pre-fill the buffer so the fast path is forced to fall through
+		// deterministically, rather than racing a waiting receiver.
+		out := make(chan *dynamic.Configuration, 1)
+		out <- nil
+
+		done := make(chan struct{})
+		go func() {
+			defer close(done)
+
+			cli.emit(nil, out, nil) // nolint:staticcheck
+		}()
+
+		// Give emit time to fall through the fast path and park on the send;
+		// draining immediately would let it take the fast path instead.
+		time.Sleep(100 * time.Millisecond)
+		require.Empty(t, done, "emit should still be blocked on the full buffer")
+
+		<-out // free a slot, unblocking the send
+
+		select {
+		case <-done:
+		case <-time.After(5 * time.Second):
+			t.Fatal("emit did not complete once the buffer drained with a nil context")
+		}
+
+		require.Len(t, out, 1)
+	})
+
+	t.Run("abandons the send when nobody is collecting", func(t *testing.T) {
+		ctx, cancel := context.WithCancel(t.Context())
+		cancel()
+
+		out := make(chan *dynamic.Configuration) // unbuffered, no receiver
+
+		done := make(chan struct{})
+		go func() {
+			defer close(done)
+
+			cli.emit(ctx, out, nil)
+		}()
+
+		select {
+		case <-done:
+		case <-time.After(5 * time.Second):
+			t.Fatal("emit blocked forever with no receiver and a cancelled context")
+		}
+
+		require.Empty(t, out)
+	})
+
+	t.Run("waits for room that frees up before the context ends", func(t *testing.T) {
+		ctx, cancel := context.WithTimeout(t.Context(), 5*time.Second)
+		defer cancel()
+
+		// Pre-filled so the fast path falls through to the blocking select.
+		out := make(chan *dynamic.Configuration, 1)
+		out <- nil
+
+		done := make(chan struct{})
+		go func() {
+			defer close(done)
+
+			cli.emit(ctx, out, nil)
+		}()
+
+		// Let emit park on the blocking select rather than taking the fast path.
+		time.Sleep(100 * time.Millisecond)
+
+		<-out // free a slot before the context expires
+
+		select {
+		case <-done:
+		case <-time.After(5 * time.Second):
+			t.Fatal("emit did not deliver once the buffer drained")
+		}
+
+		require.Len(t, out, 1)
+	})
+}

--- a/provider.go
+++ b/provider.go
@@ -52,9 +52,19 @@ func fetchConfig(top context.Context, out chan<- json.Marshaler, clients []*inte
 	for _, client := range clients {
 		run.Go(func(ctx context.Context) error {
 			if err := client.FetchRaw(ctx, merge); err != nil {
+				// Deliberately logged and swallowed. Returning the error would
+				// cancel the context shared by every fetch in this poll, and the
+				// aggregator below selects on that same context -- so a single
+				// unreachable endpoint would make it break out of its collect
+				// loop and publish a configuration missing the healthy
+				// endpoints' routers. Traefik applies that as the provider's
+				// whole config, so one dead host would drop routing for all of
+				// them.
+				//
+				// FetchRaw always emits to merge, including on failure, so the
+				// aggregator's counter still advances and the poll completes
+				// with whatever the healthy endpoints returned.
 				log.Printf("could not fetch(client:%q): %s", client.Endpoint(), err)
-
-				return err
 			}
 
 			return nil

--- a/provider_partial_test.go
+++ b/provider_partial_test.go
@@ -1,0 +1,149 @@
+package traefik_provider
+
+import (
+	"context"
+	"encoding/json"
+	"net"
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"github.com/traefik/genconf/dynamic"
+)
+
+// deadAddr binds a port and releases it immediately, so connections to it are
+// refused instantly -- the way a powered-off host behaves.
+func deadAddr(t *testing.T) *net.TCPAddr {
+	t.Helper()
+
+	ln, err := net.Listen("tcp", "127.0.0.1:0")
+	require.NoError(t, err)
+
+	addr, ok := ln.Addr().(*net.TCPAddr)
+	require.True(t, ok)
+	require.NoError(t, ln.Close())
+
+	return addr
+}
+
+// TestProvider_constructsWithUnreachableEndpoint asserts that the provider can
+// still be constructed when an endpoint is down at startup.
+//
+// Regression test: PrepareClients probed both ports of every endpoint and
+// returned on the first failure, so New() failed outright. Traefik does not
+// retry a provider that fails to start, so a single host being powered off at
+// the moment Traefik booted left every endpoint unrouted until Traefik was
+// restarted -- and bringing the host back changed nothing.
+func TestProvider_constructsWithUnreachableEndpoint(t *testing.T) {
+	data, err := os.ReadFile("fixtures/jaeger-api-rawdata.json")
+	require.NoError(t, err)
+
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusOK)
+
+		assert.NoError(t, catchError(w.Write(data)))
+	}))
+	defer srv.Close()
+
+	good, ok := srv.Listener.Addr().(*net.TCPAddr)
+	require.True(t, ok)
+
+	dead := deadAddr(t)
+
+	ctx, cancel := context.WithTimeout(t.Context(), 5*time.Second)
+	defer cancel()
+
+	resolver := "letsencrypt"
+
+	cfg := Config{
+		ConnTimeout:  "15s",
+		PollInterval: "5s",
+		TLSResolver:  &resolver,
+		Endpoints: []Endpoint{
+			{Host: dead.IP.String(), API: dead.Port, WEB: dead.Port},
+			{Host: good.IP.String(), API: good.Port, WEB: good.Port},
+		},
+	}
+
+	p, err := New(ctx, &cfg, "test")
+	require.NoError(t, err, "an endpoint being down at startup must not prevent construction")
+	require.NotNil(t, p)
+	require.NoError(t, p.Init())
+}
+
+// TestProvider_partialEndpointFailure asserts that a single unreachable endpoint
+// does not discard configuration that was fetched successfully from the healthy
+// endpoints.
+//
+// Regression test: previously a failing client returned its error from the
+// runner goroutine, which cancelled the context shared by every fetch in the
+// poll. The aggregator selects on that same context, so it could break out of
+// its collect loop before draining the healthy responses and publish an empty
+// configuration. Traefik then applied that empty config and removed every
+// router the provider owned, so one powered-off host took down routing for all
+// of them.
+//
+// The failing endpoint is a closed port so it is refused instantly, while the
+// healthy endpoint is delayed. That ordering makes the cancellation land first
+// and the race deterministic.
+func TestProvider_partialEndpointFailure(t *testing.T) {
+	data, err := os.ReadFile("fixtures/jaeger-api-rawdata.json")
+	require.NoError(t, err)
+
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		time.Sleep(75 * time.Millisecond)
+		w.WriteHeader(http.StatusOK)
+
+		assert.NoError(t, catchError(w.Write(data)))
+	}))
+	defer srv.Close()
+
+	good, ok := srv.Listener.Addr().(*net.TCPAddr)
+	require.True(t, ok)
+
+	dead := deadAddr(t)
+
+	ctx, cancel := context.WithTimeout(t.Context(), 5*time.Second)
+	defer cancel()
+
+	resolver := "letsencrypt"
+
+	cfg := Config{
+		ConnTimeout:  "15s",
+		PollInterval: "5s",
+		TLSResolver:  &resolver,
+		Endpoints: []Endpoint{
+			{Host: dead.IP.String(), API: dead.Port, WEB: dead.Port},
+			{Host: good.IP.String(), API: good.Port, WEB: good.Port},
+		},
+	}
+
+	p, err := New(ctx, &cfg, "test")
+	require.NoError(t, err)
+	require.NoError(t, p.Init())
+
+	out := make(chan json.Marshaler, 100)
+	require.NoError(t, p.Provide(out))
+
+	select {
+	case <-ctx.Done():
+		t.Fatal("provider published no configuration at all")
+	case result := <-out:
+		payload, okPayload := result.(dynamic.JSONPayload)
+		require.True(t, okPayload)
+		require.NotNil(t, payload.Configuration)
+
+		require.NotNil(t, payload.HTTP,
+			"healthy endpoint's configuration was discarded because another endpoint failed")
+
+		name := "whoami-" + good.IP.String()
+		require.Contains(t, payload.HTTP.Routers, name,
+			"router from the healthy endpoint is missing")
+		require.Contains(t, payload.HTTP.Services, name,
+			"service from the healthy endpoint is missing")
+	}
+}


### PR DESCRIPTION
Hi — thanks for this plugin, it's the backbone of routing across nine Docker hosts in my homelab.

I hit a total routing outage with it last night and traced it to two fail-closed behaviours. Either one turns a *single* unreachable endpoint into an outage for *every* endpoint the provider serves. Fixes and regression tests below.

## 1. The provider refuses to start if any endpoint is unreachable

`PrepareClients` probes both ports of every endpoint at construction and returns on the first failure, so `New()` fails outright.

**Traefik does not retry a provider that fails to start.** So if any host is down at the moment Traefik boots, the provider never initialises — no routers for *any* endpoint, no log output from the plugin at all, and no recovery when the host comes back.

That's exactly what happened to me: a power cut restarted Traefik while two hosts were intentionally powered off. All ~40 services behind the provider 404'd. Bringing those two hosts back changed nothing for two hours — only restarting Traefik itself, with every host up, recovered it.

The probe is diagnostic, so an unreachable endpoint is now logged and the client is created anyway; a later poll picks the host up when it returns.

## 2. One dead endpoint discards the healthy ones

`fetchConfig` runs every fetch under one shared cancellable context:

```go
run.Go(func(ctx context.Context) error {
    if err := client.FetchRaw(ctx, merge); err != nil {
        log.Printf(...)
        return err   // -> routine.Go calls cancel(err) on the SHARED context
    }
    return nil
})
```

The aggregator goroutine selects on that same context, so it can break out of its collect loop before draining the healthy responses and publish a configuration missing their routers. Traefik applies that as the provider's *entire* config.

It's a race, which is why I saw routers appear briefly at startup and then vanish. Client errors are now logged and swallowed; `FetchRaw` always emits to `merge`, including on failure, so the counter still advances and each poll completes with whatever the healthy endpoints returned.

## 3. Hardening: unbounded send

`FetchRaw` sent to `merge` unconditionally. If the aggregator had already stopped collecting (expired poll deadline), the send blocked forever — leaking the goroutine and hanging the `WaitGroup` the poll loop waits on, permanently stopping the provider from polling again.

Sends now fall back to a `select` on `ctx.Done()`. A non-blocking fast send is attempted first, which preserves existing behaviour for callers passing a nil or already-cancelled context — `TestClient_FetchErrors` relies on both, so that test is unchanged.

## Tests

| Test | Covers |
|---|---|
| `TestProvider_constructsWithUnreachableEndpoint` | 1 |
| `TestProvider_partialEndpointFailure` | 2, end-to-end |
| `TestClient_emit` | delivery paths incl. abandonment |

Both regression tests were verified to **fail against the unfixed code**, and #2's test was verified to **still fail with only the #1 fix applied**, so each pins its own defect rather than one masking the other. The failing endpoint is a bound-then-released port, so it's refused instantly and the ordering is deterministic rather than timing-dependent.

`go test -race -count=10 ./...` passes. No API, configuration or dependency changes.

## One behaviour change worth calling out

The provider no longer refuses to start when an endpoint is unreachable. That's the point of the fix, but it does mean a typo'd endpoint now surfaces as a logged warning per poll rather than a hard startup failure. Happy to change that to a hard failure only when *all* endpoints are unreachable if you'd prefer.

## Note

`golangci-lint run` on current `main` reports one pre-existing `prealloc` finding in `prepareResponse` (the workflow pins `version: latest`, so linter releases can break CI without a code change). I've deliberately left it alone to keep this PR to one concern — happy to send it separately.
