### PR TITLE
fix: capture the loop variable so every endpoint is actually polled (Yaegi)

### DIFF
--- a/provider.go
+++ b/provider.go
@@ -50,9 +50,18 @@ func fetchConfig(top context.Context, out chan<- json.Marshaler, clients []*inte
 
 	run := newRunner(top)
 	for _, client := range clients {
+		// Capture the loop variable explicitly. Under Go 1.22+ `client` is
+		// already per-iteration, but Traefik executes plugins through Yaegi,
+		// which still shares the loop variable across iterations. Without this
+		// every goroutine fetches from whichever endpoint the loop finished on,
+		// so the provider silently discovers only the last endpoint's routers.
+		// This compiles and passes `go test` either way -- see the PR for a
+		// standalone reproduction.
+		cli := client
+
 		run.Go(func(ctx context.Context) error {
-			if err := client.FetchRaw(ctx, merge); err != nil {
-				log.Printf("could not fetch(client:%q): %s", client.Endpoint(), err)
+			if err := cli.FetchRaw(ctx, merge); err != nil {
+				log.Printf("could not fetch(client:%q): %s", cli.Endpoint(), err)
 
 				return err
 			}

--- a/provider_multiendpoint_test.go
+++ b/provider_multiendpoint_test.go
@@ -1,0 +1,105 @@
+package traefik_provider
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"net"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"github.com/traefik/genconf/dynamic"
+)
+
+// rawDataFor returns a minimal /api/rawdata payload advertising a single router
+// and matching service under the given name.
+func rawDataFor(name string) []byte {
+	payload := fmt.Sprintf(`{
+      "routers": {
+        %[1]q: {"entryPoints":["web"],"service":%[1]q,"rule":"Host(`+"`"+`%[1]s.example.com`+"`"+`)","status":"enabled"}
+      },
+      "services": {
+        %[1]q: {"status":"enabled","loadBalancer":{"servers":[{"url":"http://127.0.0.1:1/"}]}}
+      },
+      "middlewares": {}
+    }`, name+"@docker")
+
+	return []byte(payload)
+}
+
+func serveRawData(t *testing.T, name string) *net.TCPAddr {
+	t.Helper()
+
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusOK)
+
+		assert.NoError(t, catchError(w.Write(rawDataFor(name))))
+	}))
+	t.Cleanup(srv.Close)
+
+	addr, ok := srv.Listener.Addr().(*net.TCPAddr)
+	require.True(t, ok)
+
+	return addr
+}
+
+// TestProvider_collectsFromEveryEndpoint asserts that a poll returns the routers
+// from ALL configured endpoints, not just one.
+//
+// Regression test for a loop-variable capture: `for _, client := range clients`
+// followed by a closure referencing `client` is per-iteration under Go 1.22+,
+// but Yaegi -- which is how Traefik actually executes this plugin -- shares the
+// variable across iterations. Every fetch then queries whichever endpoint the
+// loop finished on, so the provider silently serves one endpoint's routers for
+// all of them. It compiles and passes `go test` regardless, which is why it can
+// go unnoticed.
+//
+// The two endpoints advertise distinct router names so the merged configuration
+// shows exactly which ones were actually contacted.
+func TestProvider_collectsFromEveryEndpoint(t *testing.T) {
+	alpha := serveRawData(t, "alpha")
+	beta := serveRawData(t, "beta")
+
+	ctx, cancel := context.WithTimeout(t.Context(), 10*time.Second)
+	defer cancel()
+
+	cfg := Config{
+		ConnTimeout:  "15s",
+		PollInterval: "5s",
+		Endpoints: []Endpoint{
+			{Host: alpha.IP.String(), API: alpha.Port, WEB: alpha.Port},
+			{Host: beta.IP.String(), API: beta.Port, WEB: beta.Port},
+		},
+	}
+
+	p, err := New(ctx, &cfg, "test")
+	require.NoError(t, err)
+	require.NoError(t, p.Init())
+
+	out := make(chan json.Marshaler, 100)
+	require.NoError(t, p.Provide(out))
+
+	select {
+	case <-ctx.Done():
+		t.Fatal("provider published no configuration")
+	case result := <-out:
+		payload, ok := result.(dynamic.JSONPayload)
+		require.True(t, ok)
+		require.NotNil(t, payload.Configuration)
+		require.NotNil(t, payload.HTTP)
+
+		names := make([]string, 0, len(payload.HTTP.Routers))
+		for name := range payload.HTTP.Routers {
+			names = append(names, name)
+		}
+
+		require.Contains(t, names, "alpha-"+alpha.IP.String(),
+			"routers from the first endpoint are missing; got %v", names)
+		require.Contains(t, names, "beta-"+beta.IP.String(),
+			"routers from the second endpoint are missing; got %v", names)
+	}
+}


### PR DESCRIPTION
Second, independent fix — separate from #9, which is about fail-closed behaviour.

## The bug

`fetchConfig` starts one goroutine per client with a closure referencing the `client` loop variable:

```go
for _, client := range clients {
    run.Go(func(ctx context.Context) error {
        if err := client.FetchRaw(ctx, merge); err != nil {
```

Under Go 1.22+ that variable is per-iteration, so **compiled builds are correct**. But Traefik executes plugins through **Yaegi**, which still shares the loop variable across iterations.

Under Traefik, every fetch goroutine therefore queries whichever endpoint the loop finished on — so the provider silently discovers only the **last** endpoint's routers. Every other configured endpoint appears to have nothing to serve. Nothing errors, nothing logs, and `go test` passes.

## Reproduction

Rather than assert it, here's the same loop-plus-goroutine shape over three items, run both ways:

```go
for _, item := range items {
    wg.Add(1)
    go func() { defer wg.Done(); mu.Lock(); got = append(got, item); mu.Unlock() }()
}
```

```
compiled Go : captured=[alpha beta gamma]   distinct=3   ← per-iteration
yaegi       : captured=[gamma gamma gamma]  distinct=1   ← shared variable
```

## The fix

Assign the loop variable to a local before the closure, with a comment so it isn't later "modernised" away as redundant now that Go 1.22+ makes it look unnecessary.

## About the added test

`TestProvider_collectsFromEveryEndpoint` asserts a poll returns routers from **all** configured endpoints. Multi-endpoint collection currently has no coverage — every existing test configures a single endpoint — so this is useful regardless.

Being explicit about its limits: **under `go test` it passes with or without the fix**, because Go 1.22+ semantics are already correct. It documents intended behaviour and would catch the bug under Yaegi, but it is **not** a regression guard for compiled runs. I couldn't make it one: Yaegi can't execute this package's tests, because `testify` pulls in `go-spew`, which imports `unsafe`.

If you'd prefer the fix alone without the test, happy to drop it.

## Notes

- Independent of #9 — but both touch this loop, so whichever lands second will need a trivial rebase. Glad to do that.
- No API, configuration or dependency changes.
- `go test -race -count=5 ./...` passes; `gofmt` clean. The only `golangci-lint` finding is the pre-existing `prealloc` in `prepareResponse`, untouched here.
